### PR TITLE
Feature/point update 포인트 변경 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    //swagger
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //RabbitMQ
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/devit/devitpayment/DevitPaymentApplication.java
+++ b/src/main/java/com/devit/devitpayment/DevitPaymentApplication.java
@@ -3,9 +3,11 @@ package com.devit.devitpayment;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableEurekaClient
+@EnableJpaAuditing
 public class DevitPaymentApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/devit/devitpayment/common/ResponseDetails.java
+++ b/src/main/java/com/devit/devitpayment/common/ResponseDetails.java
@@ -1,0 +1,58 @@
+package com.devit.devitpayment.common;
+
+import com.devit.devitpayment.rabbitMQ.dto.UserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@RequiredArgsConstructor
+public class ResponseDetails {
+    private final static int SUCCESS = 200;
+    private final static int CREATED = 201;
+    private final static int BAD_REQUEST = 400;
+    private final static int NOT_FOUND = 404;
+    private final static int FAILED = 500;
+
+    private final static String SUCCESS_MESSAGE = "SUCCESS";
+    private final static String NOT_FOUND_MESSAGE = "NOT FOUND";
+    private final static String FAILED_MESSAGE = "Server error detected.";
+
+    @Schema
+    private Date timestamp;
+    private Object data;
+    @Schema
+    private int httpStatus;
+    @Schema
+    private String path;
+
+    public ResponseDetails(Object data, int httpStatus, String path){
+        this.timestamp = new Date();
+        this.data = data;
+        this.httpStatus = httpStatus;
+        this.path = path;
+    }
+
+    public static ResponseDetails success(Object data, String path) {
+        return new ResponseDetails(data, SUCCESS, path);
+    }
+
+    public static ResponseDetails created(Object data, String path) {
+        return new ResponseDetails(data, CREATED, path);
+    }
+
+    public static ResponseDetails fail(Object data ,String path) {
+        return new ResponseDetails(data, FAILED, path);
+    }
+
+    public static ResponseDetails badRequest(Object data ,String path) {
+        return new ResponseDetails(data, BAD_REQUEST, path);
+    }
+
+    public static ResponseDetails notFound(Object data, String path) {
+        return new ResponseDetails(data, NOT_FOUND, path);
+    }
+}

--- a/src/main/java/com/devit/devitpayment/exception/ErrorCode.java
+++ b/src/main/java/com/devit/devitpayment/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.devit.devitpayment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    INTER_SERVER_ERROR(500, "INTER SERVER ERROR"),
+    RESOURCE_NOT_FOUND(404, "RESOURCE NOT FOUND"),
+    UNAUTHORIZED(401, "UNAUTHORIZED"),
+    EXPIRED_JWT(401, "EXPIRED_JWT"),
+    BAD_REQUEST(400, "BAD_REQUEST");
+
+    private int status;
+    private String message;
+}

--- a/src/main/java/com/devit/devitpayment/exception/TokenValidFailedException.java
+++ b/src/main/java/com/devit/devitpayment/exception/TokenValidFailedException.java
@@ -1,0 +1,18 @@
+package com.devit.devitpayment.exception;
+
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(value = HttpStatus.UNAUTHORIZED)
+public class TokenValidFailedException extends RuntimeException {
+    private ErrorCode errorCode;
+    private String detail;
+
+    public TokenValidFailedException(ErrorCode errorCode, String detail) {
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/devit/devitpayment/point/controller/PointController.java
+++ b/src/main/java/com/devit/devitpayment/point/controller/PointController.java
@@ -1,0 +1,25 @@
+package com.devit.devitpayment.point.controller;
+
+import com.devit.devitpayment.common.ResponseDetails;
+import com.devit.devitpayment.point.dto.PointDto;
+import com.devit.devitpayment.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class PointController {
+    private final PointService pointService;
+
+    @PutMapping("/points")
+    public ResponseEntity<?> updatePoint(HttpServletRequest request, @RequestBody PointDto pointDto) {
+        ResponseDetails responseDetails = pointService.updatePoint(request, pointDto);
+        return new ResponseEntity<>(responseDetails, HttpStatus.valueOf(responseDetails.getHttpStatus()));
+    }
+}

--- a/src/main/java/com/devit/devitpayment/point/dto/PointDto.java
+++ b/src/main/java/com/devit/devitpayment/point/dto/PointDto.java
@@ -1,0 +1,17 @@
+package com.devit.devitpayment.point.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@Schema(description = "point 충전/사용 DTO")
+public class PointDto {
+    @Schema(description = "포인트 충전/사용", example = "CHARGE")
+    private final String type;
+    @Schema(description = "충전/사용 포인트양", example = "10000")
+    private final long amount;
+}

--- a/src/main/java/com/devit/devitpayment/point/entity/Point.java
+++ b/src/main/java/com/devit/devitpayment/point/entity/Point.java
@@ -1,0 +1,47 @@
+package com.devit.devitpayment.point.entity;
+
+import com.devit.devitpayment.point.dto.PointDto;
+import com.devit.devitpayment.rabbitMQ.dto.UserDto;
+import com.devit.devitpayment.util.Timestamped;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Point extends Timestamped {
+    @JsonIgnore
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(example = "자동 증가되는 db 내 id")
+    private long idx;
+
+    @Column(nullable = false, unique = true, columnDefinition = "BINARY(16)")
+    @Schema(example = "유저 식별 uid")
+    private UUID userUid;
+
+    @Column(nullable = false)
+    @Schema(example = "유저 보유 포인트")
+    private long point;
+
+    public Point(UserDto userDto) {
+        this.userUid = userDto.getUuid();
+        this.point = 0;
+    }
+
+    public void update(PointDto pointDto) {
+        if (Type.CHARGE == Type.of(pointDto.getType())) {
+            point += pointDto.getAmount();
+        } else if (Type.DEDUCTION == Type.of(pointDto.getType())) {
+            point -= pointDto.getAmount();
+        }
+    }
+}

--- a/src/main/java/com/devit/devitpayment/point/entity/PointRecord.java
+++ b/src/main/java/com/devit/devitpayment/point/entity/PointRecord.java
@@ -1,0 +1,60 @@
+package com.devit.devitpayment.point.entity;
+
+import com.devit.devitpayment.point.dto.PointDto;
+import com.devit.devitpayment.util.Timestamped;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointRecord extends Timestamped {
+    @JsonIgnore
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(example = "자동 증가되는 db 내 id")
+    private long idx;
+
+    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    @Schema(example = "유저 식별 uid")
+    private UUID userUid;
+
+    @JsonIgnore
+    @Column(nullable = false)
+    @Schema(example = "point 테이블과 연결되는 fk")
+    private long pointIdx;
+
+    @Column(nullable = false)
+    @Schema(example = "기존 보유 포인트")
+    private long existingPoint;
+
+    @Column(nullable = false)
+    @Schema(example = "충전/감소량")
+    private long amount;
+
+    @Column(nullable = false)
+    @Schema(example = "충전/감소")
+    private Type type;
+
+    @Column(nullable = false)
+    @Schema(example = "남은 포인트")
+    private long remainingPoint;
+
+
+    public PointRecord(UUID userUid, long idx, PointDto pointDto, Long existingPoint, Long remainingPoint) {
+        this.userUid = userUid;
+        this.pointIdx = idx;
+        this.existingPoint = existingPoint;
+        this.amount = pointDto.getAmount();
+        this.type = Type.of(pointDto.getType());
+        this.remainingPoint = remainingPoint;
+    }
+}

--- a/src/main/java/com/devit/devitpayment/point/entity/Type.java
+++ b/src/main/java/com/devit/devitpayment/point/entity/Type.java
@@ -1,0 +1,27 @@
+package com.devit.devitpayment.point.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum Type {
+    CHARGE("CHARGE", "포인트 충전"),
+    DEDUCTION("DEDUCTION", "포인트 사용"),
+    ERROR("ERROR", "포인트 충전/사용 에러 발생");
+
+    @Schema(example = "포인트 변동 -> 충전/감소")
+    private final String code;
+    @Schema(example = "포인트 변동 설명")
+    private final String displayName;
+
+    public static Type of(String code) {
+        return Arrays.stream(Type.values())
+                .filter(r -> r.getCode().equals(code))
+                .findAny()
+                .orElse(ERROR);
+    }
+}

--- a/src/main/java/com/devit/devitpayment/point/repository/PointRecordRepository.java
+++ b/src/main/java/com/devit/devitpayment/point/repository/PointRecordRepository.java
@@ -1,0 +1,7 @@
+package com.devit.devitpayment.point.repository;
+
+import com.devit.devitpayment.point.entity.PointRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointRecordRepository extends JpaRepository<PointRecord, Long>  {
+}

--- a/src/main/java/com/devit/devitpayment/point/repository/PointRepository.java
+++ b/src/main/java/com/devit/devitpayment/point/repository/PointRepository.java
@@ -1,0 +1,11 @@
+package com.devit.devitpayment.point.repository;
+
+import com.devit.devitpayment.point.entity.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PointRepository extends JpaRepository<Point, Long> {
+    Optional<Point> findByUserUid(UUID userUid);
+}

--- a/src/main/java/com/devit/devitpayment/point/service/PointService.java
+++ b/src/main/java/com/devit/devitpayment/point/service/PointService.java
@@ -1,0 +1,74 @@
+package com.devit.devitpayment.point.service;
+
+import com.devit.devitpayment.common.ResponseDetails;
+import com.devit.devitpayment.point.dto.PointDto;
+import com.devit.devitpayment.point.entity.Point;
+import com.devit.devitpayment.point.entity.PointRecord;
+import com.devit.devitpayment.point.entity.Type;
+import com.devit.devitpayment.point.repository.PointRecordRepository;
+import com.devit.devitpayment.point.repository.PointRepository;
+import com.devit.devitpayment.rabbitMQ.dto.UserDto;
+import com.devit.devitpayment.token.AuthToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PointService {
+    private final PointRepository pointRepository;
+    private final PointRecordRepository pointRecordRepository;
+    private final AuthToken authToken;
+
+    /**
+     * 요청 헤더 내 토큰 파싱하여 유저 uid 가져옴
+     */
+    public UUID tokenParse(HttpServletRequest request) {
+        return authToken.getUserUid(request);
+    }
+
+    /**
+     * 유저가 회원가입될 때 포인트 정보를 만들어줌 (point = 0)
+     */
+    public void initUser(UserDto userDto) {
+        Point point = new Point(userDto);
+        pointRepository.save(point);
+    }
+
+    /**
+     * 요청된 포인트 사용을 행할 수 있는 상태인지 확인
+     */
+    public boolean pointValidation(Long existingPoint, PointDto pointDto) {
+        if (existingPoint >= pointDto.getAmount()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public ResponseDetails updatePoint(HttpServletRequest request, PointDto pointDto) {
+        UUID userUid = tokenParse(request);
+        Optional<Point> pointOptional = pointRepository.findByUserUid(userUid);
+        String path = "/api/payment/points";
+        if (pointOptional.isEmpty()) {
+            return new ResponseDetails("유저 uid 와 매칭되는 point 정보를 찾을 수 없습니다.", 404, path);
+        }
+        Point point = pointOptional.get();
+        Long existingPoint = point.getPoint();
+        // 포인트 사용이 가능한 상태인지 확인
+        if (Type.of(pointDto.getType()) == Type.DEDUCTION && !pointValidation(existingPoint, pointDto)) {
+            return new ResponseDetails("보유 포인트가 부족합니다.", 400, path);
+        }
+        point.update(pointDto);
+        Long remainingPoint = point.getPoint();
+
+        PointRecord pointRecord = new PointRecord(userUid, point.getIdx(), pointDto, existingPoint, remainingPoint);
+        pointRecordRepository.save(pointRecord);
+        return new ResponseDetails(pointRecord, 200, path);
+    }
+}

--- a/src/main/java/com/devit/devitpayment/rabbitMQ/RabbitMqReceiver.java
+++ b/src/main/java/com/devit/devitpayment/rabbitMQ/RabbitMqReceiver.java
@@ -1,0 +1,31 @@
+package com.devit.devitpayment.rabbitMQ;
+
+import com.devit.devitpayment.point.service.PointService;
+import com.devit.devitpayment.rabbitMQ.dto.UserDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.annotation.RabbitListenerConfigurer;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RabbitMqReceiver implements RabbitListenerConfigurer {
+    private final PointService pointService;
+    private static final Logger logger = LoggerFactory.getLogger(RabbitMqReceiver.class);
+
+    public RabbitMqReceiver(PointService pointService) {
+        this.pointService = pointService;
+    }
+
+    @Override
+    public void configureRabbitListeners(RabbitListenerEndpointRegistrar rabbitListenerEndpointRegistrar) {
+    }
+
+    // 소비할 큐를 지정
+    @RabbitListener(queues = "${spring.rabbitmq.queue}")
+    public void receivedMessage(UserDto user) {
+        logger.info("User Details Received is.. " + user);
+        pointService.initUser(user);
+    }
+}

--- a/src/main/java/com/devit/devitpayment/rabbitMQ/config/RabbitMQConfig.java
+++ b/src/main/java/com/devit/devitpayment/rabbitMQ/config/RabbitMQConfig.java
@@ -1,0 +1,70 @@
+package com.devit.devitpayment.rabbitMQ.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+    // yml 파일에서 정보를 받아옴
+    @Value("${spring.rabbitmq.queue}")
+    private String queue;
+    @Value("${spring.rabbitmq.exchange}")
+    private String exchange;
+    @Value("${spring.rabbitmq.routingkey}")
+    private String routingKey;
+    @Value("${spring.rabbitmq.username}")
+    private String username;
+    @Value("${spring.rabbitmq.password}")
+    private String password;
+    @Value("${spring.rabbitmq.host}")
+    private String host;
+
+    @Bean
+    Queue queue() {
+        return new Queue(queue, true);
+    }
+
+    @Bean
+    Exchange myExchange() {
+        return ExchangeBuilder.directExchange(exchange).durable(true).build();
+    }
+
+    // queue, exchange, routingkey 로 바인딩 생성
+    @Bean
+    Binding binding() {
+        return BindingBuilder
+                .bind(queue())
+                .to(myExchange())
+                .with(routingKey)
+                .noargs();
+    }
+
+    // localhost, username(ID), password를 이용하여 CashingConnectionFactory로 초기화
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(host);
+        cachingConnectionFactory.setUsername(username);
+        cachingConnectionFactory.setPassword(password);
+        return cachingConnectionFactory;
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    // RabbitTemplate 을 ConnectionFactory 이용하여 초기화
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        final RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+        return rabbitTemplate;
+    }
+}

--- a/src/main/java/com/devit/devitpayment/rabbitMQ/dto/UserDto.java
+++ b/src/main/java/com/devit/devitpayment/rabbitMQ/dto/UserDto.java
@@ -1,0 +1,58 @@
+package com.devit.devitpayment.rabbitMQ.dto;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Component
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id", scope = UserDto.class)
+public class UserDto implements Serializable {
+    private String email;
+    private String name;
+    private UUID uuid;
+
+    public UserDto(String email, String name, UUID uuid) {
+        this.email = email;
+        this.name = name;
+        this.uuid = uuid;
+    }
+
+    public UserDto() {
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "email='" + email + '\'' +
+                ", name='" + name + '\'' +
+                ", uuid='" + uuid + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/devit/devitpayment/swagger/SwaggerConfig.java
+++ b/src/main/java/com/devit/devitpayment/swagger/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.devit.devitpayment.swagger;
+
+
+import com.fasterxml.classmate.TypeResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api(TypeResolver typeResolver) {
+        return new Docket(DocumentationType.OAS_30)
+                // additionalModels 을 추가
+                .additionalModels(
+                        typeResolver.resolve(ResponseEntity.class)
+                )
+                .useDefaultResponseMessages(false)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.devit.devitcertificationservice"))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("DevIT REST API")
+                .version("1.0.0")
+                .description("DevIT API 도구입니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/devit/devitpayment/token/AuthToken.java
+++ b/src/main/java/com/devit/devitpayment/token/AuthToken.java
@@ -1,0 +1,83 @@
+package com.devit.devitpayment.token;
+
+import com.devit.devitpayment.exception.ErrorCode;
+import com.devit.devitpayment.exception.TokenValidFailedException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthToken {
+    public static final String UID = "uuid";
+    private final Key key;
+
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    public AuthToken(String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public UUID getUserUid(HttpServletRequest request) {
+        String headerValue = request.getHeader(HEADER_AUTHORIZATION);
+        String token = null;
+
+        if (headerValue == null) {
+            return null;
+        }
+
+        if (headerValue.startsWith(TOKEN_PREFIX)) {
+            token = headerValue.substring(TOKEN_PREFIX.length());
+        }
+        return getTokenUserUid(token);
+    }
+
+    // 토큰 검증
+    public boolean validate(String token) {
+        return this.getTokenClaims(token) != null;
+    }
+
+    // 토큰 파싱 시 생길 수 있는 에러를 미리 정의
+    public Claims getTokenClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (SecurityException e) {
+            log.info("Invalid JWT signature.");
+        } catch (MalformedJwtException e) {
+            log.info("Invalid JWT token.");
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token.");
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT token compact of handler are invalid.");
+        }
+        return null;
+    }
+
+    public UUID getTokenUserUid(String token) throws TokenValidFailedException {
+
+        if (validate(token)) {
+
+            Claims claims = getTokenClaims(token);
+            log.debug("claims subject := [{}]", claims.getSubject());
+            String uid = (String) claims.get(AuthToken.UID);
+
+            return UUID.fromString(uid);
+        } else {
+            throw new TokenValidFailedException(ErrorCode.UNAUTHORIZED, "authToken not validate");
+        }
+    }
+}

--- a/src/main/java/com/devit/devitpayment/token/JwtConfig.java
+++ b/src/main/java/com/devit/devitpayment/token/JwtConfig.java
@@ -1,0 +1,16 @@
+package com.devit.devitpayment.token;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Bean
+    public AuthToken jwtProvider() {
+        return new AuthToken(secret);
+    }
+}

--- a/src/main/java/com/devit/devitpayment/util/Timestamped.java
+++ b/src/main/java/com/devit/devitpayment/util/Timestamped.java
@@ -1,0 +1,20 @@
+package com.devit.devitpayment.util;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass // 상속했을 때, 컬럼으로 인식하게 합니다.
+@EntityListeners(AuditingEntityListener.class) // 생성/수정 시간을 자동으로 반영하도록 설정
+public abstract class Timestamped {
+
+    @CreatedDate // 생성일자임을 나타냅니다.
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // 마지막 수정일자임을 나타냅니다.
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,0 @@
-server.port=0
-
-eureka.client.fetch-registry=true
-eureka.client.register-with-eureka=true
-eureka.client.service-url.defaultZone=http://localhost:8761/eureka
-
-spring.application.name=payment-service
-
-eureka.instance.instance-id=${spring.application.name}:${spring.application.instance_id:${random.value}}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,44 @@
+server:
+  port: 8080
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://54.180.93.206:8761/eureka
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/devit_payment?serverTimezone=Asia/Seoul
+    username: devit
+    password: 1234
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+  rabbitmq:
+    host: localhost
+    password: 1234
+    port: 5672
+    username: devit
+    exchange: x.devit.point_user
+    queue: q.devit.point_user
+    routingkey: devit.routingkey
+
+  application:
+    name: certification-service
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  # jwt secret key
+jwt:
+  secret: '50g/NGsxw15SwkKw8f+fxuXw6hBrEVYXCgJwyzItp8I='


### PR DESCRIPTION
* 유저 회원가입 시 인증 서비스에서 메세지큐를 통해 정보를 받고 유저 정보와 매칭되는 포인트 정보를 생성합니다.
* 이후 포인트 사용 시에 토큰에서 유저 정보를 파싱하고 해당 유저 정보와 매칭되는 포인트 정보를 찾습니다.
   * 포인트 정보가 없는 경우 404 에러를 뱉습니다.
 
200 (포인트 충전/사용 성공)
<img width="982" alt="스크린샷 2022-07-11 오후 5 13 23" src="https://user-images.githubusercontent.com/84092014/178218936-236feaed-abb5-47b8-932f-b6f9e046b617.png">
<img width="975" alt="스크린샷 2022-07-11 오후 5 13 43" src="https://user-images.githubusercontent.com/84092014/178218983-07c4d7f3-1144-46da-8e01-2ecc4636b06e.png">

400 (포인트 사용 불가 - 사용하려는 포인트의 양보다 보유 포인트가 적은 경우)
<img width="973" alt="스크린샷 2022-07-11 오후 5 14 15" src="https://user-images.githubusercontent.com/84092014/178219075-cef76675-5147-494e-8d58-670c22d2ba82.png">


404 (유저 정보와 매칭되는 포인트 정보가 없는 경우)
<img width="963" alt="스크린샷 2022-07-11 오후 5 12 48" src="https://user-images.githubusercontent.com/84092014/178218859-6a6dfad8-880c-4980-bb70-1c8966b431b8.png">