### PR TITLE
Feature/show payment record 결제 기록 리스트 구현

### DIFF
--- a/src/main/java/com/devit/devitpayment/payment/controller/PaymentController.java
+++ b/src/main/java/com/devit/devitpayment/payment/controller/PaymentController.java
@@ -6,11 +6,13 @@ import com.devit.devitpayment.payment.dto.PaymentDto;
 import com.devit.devitpayment.payment.entity.PaymentRecord;
 import com.devit.devitpayment.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -19,11 +21,21 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class PaymentController {
     private final PaymentService paymentService;
+
     @PostMapping("/payments")
     public ResponseEntity<?> updatePoint(@RequestBody PaymentDto paymentDto) throws NoResourceException, IOException {
         ResponseDetails responseDetails;
         PaymentRecord result = paymentService.createPayment(paymentDto);
         responseDetails = ResponseDetails.success(result, "/api/payment/payments");
+        return new ResponseEntity<>(responseDetails, HttpStatus.valueOf(responseDetails.getHttpStatus()));
+    }
+
+    @GetMapping("/payments")
+    public ResponseEntity<?> updatePoint(HttpServletRequest request,
+                                         @PageableDefault(page = 1, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+                                         @RequestParam(name = "fromRegDt", required = false) String fromRegDt,
+                                         @RequestParam(name = "toRegDt", required = false) String toRegDt) throws NoResourceException, IOException {
+        ResponseDetails responseDetails = paymentService.showPaymentRecord(request, pageable, fromRegDt, toRegDt);
         return new ResponseEntity<>(responseDetails, HttpStatus.valueOf(responseDetails.getHttpStatus()));
     }
 }

--- a/src/main/java/com/devit/devitpayment/payment/controller/PaymentController.java
+++ b/src/main/java/com/devit/devitpayment/payment/controller/PaymentController.java
@@ -32,7 +32,7 @@ public class PaymentController {
 
     @GetMapping("/payments")
     public ResponseEntity<?> updatePoint(HttpServletRequest request,
-                                         @PageableDefault(page = 1, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+                                         @PageableDefault(page = 1, size = 10, sort = "created_at", direction = Sort.Direction.DESC) Pageable pageable,
                                          @RequestParam(name = "fromRegDt", required = false) String fromRegDt,
                                          @RequestParam(name = "toRegDt", required = false) String toRegDt) throws NoResourceException, IOException {
         ResponseDetails responseDetails = paymentService.showPaymentRecord(request, pageable, fromRegDt, toRegDt);

--- a/src/main/java/com/devit/devitpayment/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/devit/devitpayment/payment/repository/PaymentRepository.java
@@ -1,7 +1,23 @@
 package com.devit.devitpayment.payment.repository;
 
 import com.devit.devitpayment.payment.entity.PaymentRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 public interface PaymentRepository extends JpaRepository<PaymentRecord, Long> {
+    @Query(value = "SELECT * FROM payment_record p WHERE (p.buyer_uid = :userUid OR p.provider_uid =:userUid) AND p.created_at BETWEEN :fromDateTime AND :toDateTime",
+            countQuery = "SELECT count(*) FROM payment_record",
+            nativeQuery = true)
+    Page<PaymentRecord> findAllByBuyerUidOrProviderUidAndCreatedAtBetween(Pageable pageable, @Param("userUid") UUID userUid, @Param("fromDateTime") LocalDateTime fromDateTime, @Param("toDateTime") LocalDateTime toDateTime);
+
+    @Query(value = "SELECT * FROM payment_record p WHERE p.buyer_uid = :userUid OR p.provider_uid = :userUid",
+            countQuery = "SELECT count(*) FROM payment_record",
+            nativeQuery = true)
+    Page<PaymentRecord> findAllByBuyerUidOrProviderUid(Pageable pageable, @Param("userUid") UUID userUid);
 }

--- a/src/main/java/com/devit/devitpayment/token/TokenParse.java
+++ b/src/main/java/com/devit/devitpayment/token/TokenParse.java
@@ -1,0 +1,21 @@
+package com.devit.devitpayment.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TokenParse {
+    private final AuthToken authToken;
+    /**
+     * 요청 헤더 내 토큰 파싱하여 유저 uid 가져옴
+     */
+    public UUID tokenParse(HttpServletRequest request) {
+        return authToken.getUserUid(request);
+    }
+
+
+}


### PR DESCRIPTION
결제 기록 리스트 조회 API 를 구현하였습니다.
페이징이 되도록 하였고 기본 값으로 Page = 1, PageSize = 10, sort = created_at, desc 를 주었습니다.

fromRegDt 는 조회를 시작할 날짜이며 toRegDt 는 조회를 할 마지막 기록 날짜입니다.
fromRegDt ~ toRegDt ex ) 220717 ~ 220718

요청 --
<img width="1130" alt="스크린샷 2022-07-18 오후 5 59 07" src="https://user-images.githubusercontent.com/84092014/179477962-55616dfe-b93f-4844-b5df-6dc4aae5afc9.png">

응답 --
<img width="1118" alt="스크린샷 2022-07-18 오후 5 59 29" src="https://user-images.githubusercontent.com/84092014/179478030-158072e3-e75e-4f85-acb9-59cd2659d2eb.png">

